### PR TITLE
Optional focus

### DIFF
--- a/notes/Spellings and Sounds/front-01.html
+++ b/notes/Spellings and Sounds/front-01.html
@@ -71,8 +71,12 @@ function playAudio(id) {
 
     playAudio('#to_play');
 
-    // focusing filling area
-    document.getElementById("typeans").focus();
+    // Try focusing filling area
+    try {
+        document.getElementById("typeans").focus();
+    } catch (e) {
+        // Ignore
+    }
 
     // Saving data
     Persistence.setItem(JSON.stringify(posibilities));


### PR DESCRIPTION
Fixes the play button on Anki iOS in "initials" and "finals" decks.

Before this fix, a javascript error was displayed instead of the play button.